### PR TITLE
Fix build break and memory-safety issues

### DIFF
--- a/DeadEndsLib/Gedcom/writenode.c
+++ b/DeadEndsLib/Gedcom/writenode.c
@@ -116,13 +116,12 @@ int treeStringLength(int level, GNode* gnode) {
 
 // nodeStringLength returns the a GNode's string length; it counts the \n but not the final 0.
 static int nodeStringLength(int level, GNode* gnode) {
-    if (gnode->key && gnode->value) {
-        return snprintf(null, 0, "%d %s %s %s\n", level, gnode->key, gnode->tag, gnode->value);
-    } else if (gnode->key) {
-        return snprintf(null, 0, "%d %s %s\n", level, gnode->key, gnode->tag);
-    } else if (gnode->value) {
-        return snprintf(null, 0, "%d %s %s\n", level, gnode->tag, gnode->value);
-    } else {
-        return snprintf(null, 0, "%d %s\n", level, gnode->tag);
-    }
+    char scratch[32];
+    int wrote = snprintf(scratch, sizeof(scratch), "%d", level);
+    if (wrote < 0) return 0;
+    size_t len = (size_t) wrote + 1;
+    if (gnode->key) len += strlen(gnode->key) + 1;
+    len += strlen(gnode->tag);
+    if (gnode->value) len += strlen(gnode->value) + 1;
+    return (int) len + 1;
 }

--- a/DeadEndsLib/Gedcom/writenode.c
+++ b/DeadEndsLib/Gedcom/writenode.c
@@ -116,12 +116,13 @@ int treeStringLength(int level, GNode* gnode) {
 
 // nodeStringLength returns the a GNode's string length; it counts the \n but not the final 0.
 static int nodeStringLength(int level, GNode* gnode) {
-    size_t len;
-    char scratch[10];  // To hold the level.
-    sprintf(scratch, "%d", level);
-    len = strlen(scratch) + 1;
-    if (gnode->key) len += strlen(gnode->key) + 1;
-    len += strlen(gnode->tag);
-    if (gnode->value) len += strlen(gnode->value) + 1;
-    return (int) len + 1;
+    if (gnode->key && gnode->value) {
+        return snprintf(null, 0, "%d %s %s %s\n", level, gnode->key, gnode->tag, gnode->value);
+    } else if (gnode->key) {
+        return snprintf(null, 0, "%d %s %s\n", level, gnode->key, gnode->tag);
+    } else if (gnode->value) {
+        return snprintf(null, 0, "%d %s %s\n", level, gnode->tag, gnode->value);
+    } else {
+        return snprintf(null, 0, "%d %s\n", level, gnode->tag);
+    }
 }

--- a/DeadEndsLib/Gedcom/writenode.c
+++ b/DeadEndsLib/Gedcom/writenode.c
@@ -70,7 +70,7 @@ String gnodesToString(GNode* gnode) {
 
 /// Returns a `GNode` as a Gedcom `String` without newline.
 String gnodeToString(GNode* gnode, int level) {
-    int length = nodeStringLength(level, gnode);
+    int length = nodeStringLength(level, gnode) + 1;
     String string = (String) stdalloc(length);
     swriteGNode(level, gnode, string);
     string[strlen(string) - 1] = 0;
@@ -79,25 +79,16 @@ String gnodeToString(GNode* gnode, int level) {
 
 // swriteGNode writes a GNode to a string and returns the position in string of next GNode.
 static String swriteGNode(int level, GNode* node, String p) {
-    char scratch[600];
-    String q = scratch;
-    sprintf(q, "%d ", level);
-    q += strlen(q);
-    if (node->key) {
-        strcpy(q, node->key);
-        q += strlen(q);
-        *q++ = ' ';
+    size_t length = (size_t) nodeStringLength(level, node) + 1;
+    if (node->key && node->value) {
+        snprintf(p, length, "%d %s %s %s\n", level, node->key, node->tag, node->value);
+    } else if (node->key) {
+        snprintf(p, length, "%d %s %s\n", level, node->key, node->tag);
+    } else if (node->value) {
+        snprintf(p, length, "%d %s %s\n", level, node->tag, node->value);
+    } else {
+        snprintf(p, length, "%d %s\n", level, node->tag);
     }
-    strcpy(q, node->tag);
-    q += strlen(q);
-    if (node->value) {
-        *q++ = ' ';
-        strcpy(q, node->value);
-        q += strlen(q);
-    }
-    *q++ = '\n';
-    *q = 0;
-    strcpy(p, scratch);
     return p + strlen(p);
 }
 

--- a/DeadEndsLib/Utils/errors.c
+++ b/DeadEndsLib/Utils/errors.c
@@ -9,18 +9,19 @@
 #include "list.h"
 
 #define NUMKEYS 64
+#define ERRORKEYSIZE 128
 static bool debugging = false;
 
 // getKey returns the comparison key of an error.
 static String getKey(void* error) {
-	static char buffer[NUMKEYS][128];
+	static char buffer[NUMKEYS][ERRORKEYSIZE];
 	static int dex = 0;
 	if (++dex > NUMKEYS - 1) dex = 0;
 	String scratch = buffer[dex];
 	String fileName = ((Error*) error)->fileName;
 	if (!fileName) fileName = "";
 	int lineNumber = ((Error*) error)->lineNumber;
-	snprintf(scratch, sizeof(buffer[0]), "%s%09d", fileName, lineNumber);
+	snprintf(scratch, ERRORKEYSIZE, "%s%09d", fileName, lineNumber);
 	return scratch; // Static memory!
 }
 

--- a/DeadEndsLib/Utils/errors.c
+++ b/DeadEndsLib/Utils/errors.c
@@ -20,7 +20,7 @@ static String getKey(void* error) {
 	String fileName = ((Error*) error)->fileName;
 	if (!fileName) fileName = "";
 	int lineNumber = ((Error*) error)->lineNumber;
-	sprintf(scratch, "%s%09d", fileName, lineNumber);
+	snprintf(scratch, sizeof(buffer[0]), "%s%09d", fileName, lineNumber);
 	return scratch; // Static memory!
 }
 

--- a/DeadEndsLib/Utils/path.c
+++ b/DeadEndsLib/Utils/path.c
@@ -21,14 +21,14 @@ String resolveFile(String name, String path, String suffix) {
     char fullpath[MAXPATHBUFFER];
 
     // Search path list for the filename.
-    strcpy(pathbuf, path);
+    if (snprintf(pathbuf, sizeof(pathbuf), "%s", path) >= sizeof(pathbuf)) return null;
     for (char* dir = strtok(pathbuf, ":"); dir; dir = strtok(null, ":")) {
         snprintf(fullpath, sizeof(fullpath), "%s/%s", dir, name);
         if (access(fullpath, F_OK) == 0) return strsave(fullpath);
     }
     // Try with suffix if provided.
     if (!suffix || !*suffix) return null;
-    strcpy(pathbuf, path);  // Reset buf because strtok modifies it
+    if (snprintf(pathbuf, sizeof(pathbuf), "%s", path) >= sizeof(pathbuf)) return null; // Reset buf because strtok modifies it
     String fmt = (*suffix == '.') ? "%s/%s%s" : "%s/%s.%s";
     for (char* dir = strtok(pathbuf, ":"); dir; dir = strtok(null, ":")) {
         snprintf(fullpath, sizeof(fullpath), fmt, dir, name, suffix);

--- a/Partition/main.c
+++ b/Partition/main.c
@@ -88,12 +88,15 @@ int main(int argc, char** argv) {
 		GNodeIndexEl* element = searchHashTable(index, person->key);
 		ConnectData* data = element->data;
 		int score = data->numAncestors + data->numDescendents;
-		if (score > max) {
+		if (!topGun || score > max) {
 			max = score;
 			topGun = person;
 		}
 	ENDLIST
-	printf("Person: %s %s %d\n", topGun->key, topGun->child->value, max);
+	if (topGun)
+		printf("Person: %s %s %d\n", topGun->key, topGun->child->value, max);
+	else
+		printf("Person: (none) (none) 0\n");
 	if (timing) printf("%s: Partition: done.\n", gms);
 }
 

--- a/RunScript/runscript.c
+++ b/RunScript/runscript.c
@@ -44,7 +44,7 @@ int main(int argc, char* argv[]) {
 
     // Parse the program script.
     fprintf(stderr, "%s: Script parsed.\n", getMsecondsStr());
-    Program* program = parseProgram(scriptFile, scriptPath);
+    Program* program = parseProgram(scriptFile, scriptPath, errorLog);
     if (!program) {
         fprintf(stderr, "Error parsing program\n");
         exit(1);


### PR DESCRIPTION
## Summary\n- fix RunScript build break by passing the required ErrorLog to parseProgram\n- replace unsafe fixed-buffer copies in path and error-key code\n- remove fixed-size stack overflow risk in GEDCOM node string writer\n- guard Partition topGun output when no person records are present\n\n## Verification\n- make all